### PR TITLE
fix(helpers): show color value when auto-detecting

### DIFF
--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/css/preview.css
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/css/preview.css
@@ -637,7 +637,7 @@ a.ds-toggle__trigger:hover {
   height: auto;
 }
 
-.ds-color__value--detect,
+.ds-color__value,
 .ds-color--set {
   text-transform: uppercase;
 } 

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/js/preview.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/js/preview.js
@@ -222,10 +222,12 @@
     // Gather info
     Array.prototype.forEach.call(detectContainerEls, function (el, i) {
       const previewSelector = el.dataset.target;
+      let previewEl;
       if (!previewSelector) {
-        return;
+        previewEl = el;
+      } else {
+        previewEl = findEl(el, previewSelector);
       }
-      const previewEl = findEl(el, previewSelector);
       if (!previewEl) {
         return;
       }

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
@@ -104,6 +104,27 @@ module.exports = function (self, options) {
         ...options,
         type: 'p'
       });
+    },
+
+    // Used only for color palettes
+    normalizeColorPalette(arr, options = {}) {
+      const opts = { ...options };
+      // defaults
+      if (typeof opts.showClass === 'undefined') {
+        opts.showClass = false;
+      }
+
+      return arr
+        .map(item => {
+          if (typeof item === 'string') {
+            return { value: item };
+          }
+          return item;
+        })
+        .map(item => ({
+          ...options,
+          ...item
+        }));
     }
   };
 };

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/utils.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/utils.js
@@ -50,13 +50,14 @@ function normalizeTypeHelper(arr, options = {}) {
 
     // Merge global with item data
     const {
-      font, color, weight, tracking, padding, background, image, label
+      font, color, weight, tracking, padding, background, image, label, truncate
     } = options;
     res = {
       weight,
       tracking,
       padding,
       label,
+      truncate,
       ...res,
       font,
       color,

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/colors.html
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/colors.html
@@ -7,7 +7,9 @@
     <div class="ds-color__info">
       {{ name }}
       <code class="ds-summary-line">{% if varName %}{{ varName }}:&nbsp;{%endif%}<span class="ds-color--set" data-type="background"></span></code>
-      <code class="ds-summary-line">.{{ value }}</code>
+      {% if options.showClass %}
+        <code class="ds-summary-line">.{{ value }}</code>
+      {% endif %}
       {% if details %}
         <section class="ds-color__details">
           {{ details }}
@@ -47,17 +49,23 @@
     <div class="ds-color-palette{%if options.horizontal%} ds-color-palette--horizontal{%endif%}">
     {% for cols in colors %}
       <div class="ds-color-palette__col">
-        {% for item in cols %}
+        {% set collection = apos.dsp.normalizeColorPalette(cols, options) %}
+        {% for item in collection %}
           {% if options.detect %}
             <div class="ds-color-palette__cell {{ item.value }} ds-color--detect ds-color__preview" style="{% if item.color %}color:{{ item.color }};{% endif %}">
               {{ item.name }}
-              <code class="ds-summary-line">{% if item.varName %}{{ item.varName }}: {%endif%}<span class="ds-color__value--detect"></span></code>
-              <code class="ds-summary-line">.{{ item.value }}</code>
+              <code class="ds-summary-line">
+                {% if item.varName %}{{ item.varName }}: {%endif%}
+                <span class="ds-color--set" data-type="background">{{ item.value }}</span>
+              </code>
+              {% if item.showClass %}
+                <code class="ds-summary-line">.{{ item.value }}</code>
+              {% endif %}
             </div>
           {% else %}
             <div class="ds-color-palette__cell" style="background: {{item.value}} none repeat scroll 0% 0%;{% if item.color %}color:{{ item.color }};{% endif %}">
               {{ item.name }}
-              <code class="ds-summary-line">{% if item.varName %}{{ item.varName }}: {%endif%}<span class="ds-color__value--detect">{{ item.value }}</span></code>
+              <code class="ds-summary-line">{% if item.varName %}{{ item.varName }}: {%endif%}<span class="ds-color__value">{{ item.value }}</span></code>
             </div>
           {% endif %}
         {% endfor %}

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/type.html
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/type.html
@@ -179,7 +179,7 @@ Verba tu fingas et ea dicas, quae non sentias?
 
 {% macro headingPreview(item, options) %}
   {% set cls = ' ' + item.cls if item.cls %}
-  {% if options.truncate %}
+  {% if item.truncate %}
     {% set cls = cls + ' ds-heading__preview--truncated' %}
   {% endif %}
   {% set label = pangramSingle if options.single else pangram %}

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/colors.njk
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/colors.njk
@@ -138,8 +138,8 @@
   {% enddssection %}
 
   {% dssection 'Colors with auto detect' %}
-    {{ colors.color('Primary', 'trs-demo-color-primary', "$trs-primary-color", { detect: true }) }}
-    {{ colors.color('Secondary', 'trs-demo-color-secondary', "$trs-secondary-color", { detect: true }) }}
+    {{ colors.color('Primary', 'trs-demo-color-primary', "$trs-primary-color", { detect: true, showClass: true }) }}
+    {{ colors.color('Secondary', 'trs-demo-color-secondary', "$trs-secondary-color", { detect: true, showClass: true }) }}
     {{ colors.color('Background Dark', 'trs-demo-color-bg-dark', '', { span: 2, detect: true }) }}
     {{ colors.color('Background Light', 'trs-demo-color-bg', '', { span: 2, detect: true }) }}
 
@@ -147,8 +147,8 @@
       {% raw %}
       {% import "@corllete/apos-ds-page-type:components/story/colors.html" as colors %}
 
-      {{ colors.color('Primary', 'trs-demo-color-primary', "$trs-primary-color", { detect: true }) }}
-      {{ colors.color('Secondary', 'trs-demo-color-secondary', "$trs-secondary-color", { detect: true }) }}
+      {{ colors.color('Primary', 'trs-demo-color-primary', "$trs-primary-color", { detect: true, showClass: true }) }}
+      {{ colors.color('Secondary', 'trs-demo-color-secondary', "$trs-secondary-color", { detect: true, showClass: true }) }}
       {{ colors.color('Background Dark', 'trs-demo-color-bg-dark', '', { span: 2, detect: true }) }}
       {{ colors.color('Background Light', 'trs-demo-color-bg', '', { span: 2, detect: true }) }}
       
@@ -306,25 +306,29 @@
   {% dssection 'Color palette - auto-detect color value from class name' %}
     {{ colors.palette([
       [
-        {name: "100", value: "trs-demo-color-palette1"},
+        {name: "100", value: "trs-demo-color-palette1", varName: "$some-sass-var", showClass: false},
         {name: "200", value: "trs-demo-color-palette2"},
         {name: "300", value: "trs-demo-color-palette3"},
-        {name: "400", value: "trs-demo-color-palette4"}
+        {name: "400", value: "trs-demo-color-palette4", showClass: false}
       ]
-    ], { detect: true }) }}
+    ], { detect: true, showClass: true }) }}
 
     {% dscodecell 12, 'njk', { toggle: false } %}
       {% raw %}
       {% import "@corllete/apos-ds-page-type:components/story/colors.html" as colors %}
 
+      {# 
+        showClass is enabled globally and can be adjusted by item.
+        Enabling showClass makes only sense when you do auto-detection.
+      #}
       {{ colors.palette([
         [
-          {name: "100", value: "trs-demo-color-palette1"},
+          {name: "100", value: "trs-demo-color-palette1", varName: "$some-sass-var", showClass: false},
           {name: "200", value: "trs-demo-color-palette2"},
           {name: "300", value: "trs-demo-color-palette3"},
-          {name: "400", value: "trs-demo-color-palette4"}
+        {name: "400", value: "trs-demo-color-palette4", showClass: false}
         ]
-      ], { detect: true }) }}
+      ], { detect: true, showClass: true }) }}
       
       {% endraw %}
     {% enddscodecell %}
@@ -333,24 +337,24 @@
   {% dssection 'Color palette - multi' %}
     {{ colors.palette([
       [
-        {value: "#ffff00"},
-        {value: "#ffff22"},
-        {value: "#ffff44"},
-        {value: "#ffff66"},
-        {value: "#ffff88"},
-        {value: "#ffffaa"},
-        {value: "#ffffcc"},
-        {value: "#ffffee"}
+        "#ffff00",
+        "#ffff22",
+        "#ffff44",
+        "#ffff66",
+        "#ffff88",
+        "#ffffaa",
+        "#ffffcc",
+        "#ffffee"
       ],
       [
-        {value: "#ff00ff"},
-        {value: "#ff22ff"},
-        {value: "#ff44ff"},
-        {value: "#ff66ff"},
-        {value: "#ff88ff"},
-        {value: "#ffaaff"},
-        {value: "#ffccff"},
-        {value: "#ffeeff"}
+        "#ff00ff",
+        "#ff22ff",
+        "#ff44ff",
+        "#ff66ff",
+        "#ff88ff",
+        "#ffaaff",
+        "#ffccff",
+        "#ffeeff"
       ],
       [
         {value: "#00ffff"},
@@ -368,26 +372,27 @@
       {% raw %}
       {% import "@corllete/apos-ds-page-type:components/story/colors.html" as colors %}
 
+      {# You may provide string instead of object if you don't need other options #}
       {{ colors.palette([
         [
-          {value: "#ffff00"},
-          {value: "#ffff22"},
-          {value: "#ffff44"},
-          {value: "#ffff66"},
-          {value: "#ffff88"},
-          {value: "#ffffaa"},
-          {value: "#ffffcc"},
-          {value: "#ffffee"}
+          "#ffff00",
+          "#ffff22",
+          "#ffff44",
+          "#ffff66",
+          "#ffff88",
+          "#ffffaa",
+          "#ffffcc",
+          "#ffffee"
         ],
         [
-          {value: "#ff00ff"},
-          {value: "#ff22ff"},
-          {value: "#ff44ff"},
-          {value: "#ff66ff"},
-          {value: "#ff88ff"},
-          {value: "#ffaaff"},
-          {value: "#ffccff"},
-          {value: "#ffeeff"}
+          "#ff00ff",
+          "#ff22ff",
+          "#ff44ff",
+          "#ff66ff",
+          "#ff88ff",
+          "#ffaaff",
+          "#ffccff",
+          "#ffeeff"
         ],
         [
           {value: "#00ffff"},

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/types.njk
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/types.njk
@@ -332,7 +332,8 @@
           margin: '0',
           cls: 'ds-demo-type-color',
           className: '.some-slass-as-info, h2',
-          varName: '$ds-heading-text-color'
+          varName: '$ds-heading-text-color',
+          truncate: true
         }
       ], 
       { 
@@ -344,6 +345,7 @@
         background: '#ff5555',
         cls: 'container-class',
         single: true,
+        truncate: false,
         details: true
       }
     ) }}
@@ -351,13 +353,22 @@
       <div class="ds-typography--code ds-justify">
         All possible heading object and options properties. 
         <code>font, color, background, image</code> can be only set in options.
-        <code>weight, tracking, padding, label</code> can be set as defaults in options
+        <code>weight, tracking, padding, label, truncate</code> can be set as defaults in options
         and overridden by the heading items.<br />
-        <code>margin</code> doesn't make sense in typography context, but you still have 
-        the chance to force it. Class options will be overriden by the manual values (style tag property) for both
-        options and heading objects. <code>background</code> and <code>image</code> options can be
-        boolean <code>true</code> or color/image url. In the former case they would be only shown in details 
-        and their values will be auto detected from the css computed data (requires force detect option).
+        <p>
+          <code>margin</code> doesn't make sense in typography context, but you still have 
+          the chance to force it. Class options will be overriden by the manual values (style tag property) for both
+          options and heading objects. 
+        </p>
+        <p>
+          <code>background</code> and <code>image</code> options can be
+          boolean <code>true</code> or color/image url. In the former case they would be only shown in details 
+          and their values will be auto detected from the css computed data (requires force detect option).
+        </p>
+        <p> 
+          <code>color, weight, tracking, line</code> could have boolean value when auto-detect and details are enabled in which 
+          case they will be added in the details section.
+        </p>
       </div>
     {% enddscell %}
     {% dscodecell 12, 'njk', { toggle: false } %}
@@ -377,7 +388,8 @@
             margin: '0',
             cls: 'ds-demo-type-color',
             className: '.some-slass-as-info, h',
-            varName: '$ds-heading-text-color'
+            varName: '$ds-heading-text-color',
+            truncate: true
           }
         ], 
         { 
@@ -389,6 +401,7 @@
           background: '#ff5555',
           cls: 'container-class',
           single: true,
+          truncate: false,
           details: true
         }
       ) }}


### PR DESCRIPTION
Add some more improvements like control over what will be shown and when for colors and color palettes. Also improve the behaviour of the heading truncate options (messed up with the previous pull request)

closes #8