### PR TITLE
feat(helpers): add custom type helper

### DIFF
--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/css/preview.css
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/css/preview.css
@@ -444,37 +444,45 @@ body, html {
 
 /* Heading/paragraph specimen */
 .ds-paragraph,
+.ds-custom-type,
 .ds-heading {
   padding: 0.8rem 1.2rem;
   border-radius: 4px;
 }
 
 .ds-heading__item:not(:last-child),
+.ds-custom-type__item:not(:last-child),
 .ds-paragraph__item:not(:last-child) {
   margin-bottom: 2rem;
 }
 
 .ds-paragraph__meta,
+.ds-custom-type__meta,
 .ds-heading__meta {
   margin: 10px 0;
 }
 
 .ds-paragraph__header,
+.ds-custom-type__header,
 .ds-heading__header,
 .ds-paragraph__meta,
+.ds-custom-type__meta,
 .ds-heading__meta,
 .ds-paragraph__details,
+.ds-custom-type__details,
 .ds-heading__details {
   font-family: 'Roboto Mono', monospace;
   font-size: 1.2rem;
 }
 
 .ds-paragraph__details,
+.ds-custom-type__details,
 .ds-heading__details {
   font-size: 1rem;
 }
 
 .ds-paragraph__header,
+.ds-custom-type__header,
 .ds-heading__header {
   -moz-opacity: 0.7;
   opacity: 0.7;
@@ -484,8 +492,19 @@ body, html {
   margin-bottom: 1rem;
 }
 
+.ds-type--set[data-type="font"] {
+  cursor: pointer;
+}
+
+.ds-type--set[data-type="font"]::after {
+  content: "(...)";
+  padding-left: 5px;
+}
+
 .ds-paragraph__meta,
 .ds-paragraph__details,
+.ds-custom-type__meta,
+.ds-custom-type__details,
 .ds-heading__meta,
 .ds-heading__details {
   -moz-opacity: 0.5;
@@ -504,6 +523,7 @@ body, html {
 }
 
 .ds-paragraph__details,
+.ds-custom-type__details,
 .ds-heading__details {
 	margin: 10px 0 0 0;
 	list-style-type: none;
@@ -511,6 +531,7 @@ body, html {
 }
 
 .ds-heading__crating,
+.ds-custom-type__crating,
 .ds-paragraph__crating {
   /* height: 25px; */
   color: #ffffff;
@@ -521,6 +542,7 @@ body, html {
 }
 
 .ds-heading__crating .ds-toggle__trigger,
+.ds-custom-type__crating .ds-toggle__trigger,
 .ds-paragraph__crating .ds-toggle__trigger {
   padding: 0;
 }
@@ -537,15 +559,19 @@ a.ds-toggle__trigger:hover {
   text-decoration: none;	
 }
 
-.ds-paragraph__crating--details {
+.ds-paragraph__crating--details,
+.ds-custom-type__crating--details {
   padding-top: 1rem;
 }
 
 .ds-heading__toggle-icon,
 .ds-paragraph__toggle-icon,
+.ds-custom-type__toggle-icon,
 .ds-heading__crating--label,
 .ds-paragraph__crating--label,
+.ds-custom-type__crating--label,
 .ds-heading__crating--ratio,
+.ds-custom-type__crating--ratio,
 .ds-paragraph__crating--ratio {
   display: inline-block;
   color: #ffffff;
@@ -553,6 +579,7 @@ a.ds-toggle__trigger:hover {
 }
 
 .ds-heading__crating--label,
+.ds-custom-type__crating--label,
 .ds-paragraph__crating--label {
   text-transform: uppercase;
   font-weight: 600;
@@ -560,7 +587,9 @@ a.ds-toggle__trigger:hover {
 
 .ds-heading__toggle-icon,
 .ds-paragraph__toggle-icon,
+.ds-custom-type__toggle-icon,
 .ds-heading__crating--ratio,
+.ds-custom-type__crating--ratio,
 .ds-paragraph__crating--ratio {
   padding-left: 1rem;
   font-weight: 400;

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/js/preview.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/assets/js/preview.js
@@ -183,6 +183,7 @@
             .trim()
             .replace(/'/g, '')
             .replace(/"/g, '');
+          el.title = style.fontFamily || '';
           break;
         case 'size':
           el.textContent = style.fontSize;
@@ -214,6 +215,20 @@
       }
     });
   }
+
+  // function getIfCssVariableFn(computed) {
+  //   if (typeof computed.getPropertyValue === 'function') {
+  //     return function getIfCssVariable(aVar) {
+  //       if (typeof computed.getPropertyValue === 'function' && (aVar || '').slice(0, 2) === '--') {
+  //         return computed.getPropertyValue(aVar);
+  //       }
+  //       return aVar;
+  //     };
+  //   }
+  //   return function getIfCssVariableNone(aVar) {
+  //     return aVar;
+  //   };
+  // }
 
   function findAndReplace(detectSelector, setSelector, replacer) {
     const detectContainerEls = document.querySelectorAll(detectSelector);

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
@@ -106,6 +106,20 @@ module.exports = function (self, options) {
       });
     },
 
+    normalizeCustomTypes(arr, options = {}) {
+      return normalizeTypeHelper(arr, {
+        ...options,
+        type: 'custom'
+      });
+    },
+
+    normalizeCustomTypeOptions(options = {}) {
+      return normalizeTypeOptionsHelper({
+        ...options,
+        type: 'custom'
+      });
+    },
+
     // Used only for color palettes
     normalizeColorPalette(arr, options = {}) {
       const opts = { ...options };

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/utils.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/utils.js
@@ -38,6 +38,11 @@ function normalizeTypeHelper(arr, options = {}) {
               label: 'p.' + h
             };
           }
+        } else if (options.type === 'custom') {
+          // custom type
+          res = {
+            tag: h
+          };
         } else {
           // Header - it's a css class name
           res = {
@@ -50,7 +55,7 @@ function normalizeTypeHelper(arr, options = {}) {
 
     // Merge global with item data
     const {
-      font, color, weight, tracking, padding, background, image, label, truncate
+      font, color, weight, tracking, padding, background, image, label, truncate, content
     } = options;
     res = {
       weight,
@@ -58,12 +63,26 @@ function normalizeTypeHelper(arr, options = {}) {
       padding,
       label,
       truncate,
+      content,
       ...res,
       font,
       color,
       background,
       image
     };
+
+    // custom type with defaults
+    if (options.type === 'custom') {
+      if (!res.tag) {
+        res.tag = 'div';
+      }
+      if (!res.content) {
+        res.content = res.tag;
+      }
+      if (!res.label) {
+        res.label = res.tag;
+      }
+    }
 
     // normalize size
     if (typeof res.size === 'number') {
@@ -121,6 +140,7 @@ function normalizeTypeOptionsHelper(options = {}) {
   switch (opts.type) {
     case 'p':
     case 'h':
+    case 'custom':
       // both
       if (typeof opts.color === 'undefined') {
         opts.color = true;

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/type.html
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/story/type.html
@@ -30,6 +30,9 @@ Verba tu fingas et ea dicas, quae non sentias?
     {% if obj.paragraphs %}
       {{ paragraphs(obj.paragraphs, options) }}
     {% endif %}
+    {% if obj.custom %}
+      {{ customTypes(obj.custom, options) }}
+    {% endif %}
   {% enddscell %}
 {% endmacro %}
 
@@ -39,6 +42,9 @@ Verba tu fingas et ea dicas, quae non sentias?
   {% endif %}
   {% if obj.paragraphs %}
     {{ paragraphs(obj.paragraphs, options) }}
+  {% endif %}
+  {% if obj.custom %}
+    {{ customTypes(obj.custom, options) }}
   {% endif %}
 {% endmacro %}
 
@@ -177,6 +183,73 @@ Verba tu fingas et ea dicas, quae non sentias?
   {% endif %}
 {% endmacro %}
 
+
+
+{% macro custom(arr, options) %}
+  {% dscell options.span %}
+    {{ customTypes(arr, options) }}
+  {% enddscell %}
+{% endmacro %}
+
+{% macro customTypes(items, opts) %}
+  {% set rootId = apos.util.generateId() %}
+  {% set options = apos.dsp.normalizeCustomTypeOptions(opts) %}
+  {% set collection = apos.dsp.normalizeCustomTypes(items, options) %}
+  {% set cls = ' ' + options.cls %}
+  {% if options.detect %}
+    {% set cls = cls + ' ds-type--detect-global' %}
+  {% endif %}
+  {% if options.rating %}
+    {% set cls = cls + ' ds-type-fix-top-border' %}
+    <div 
+      class="ds-type--detect-crating"
+      data-root-target="self"
+      data-preview-target=".ds-custom-type__crating"
+      data-background-target=".ds-custom-type"
+      data-foreground-target=".ds-custom-type__preview">
+      <div class="ds-custom-type__crating ds-toggle"{#  data-toggle-state="false" #}>
+        <a class="ds-toggle__trigger" href="#" title="Toggle code">
+          <span class="ds-custom-type__crating--label ds-type--set-crating" data-type="crating-label">Not detected</span>
+          <span class="ds-custom-type__crating--ratio ds-type--set-crating" data-type="crating-ratio"></span>
+          <span class="ds-custom-type__toggle-icon ds-toggle__icon material-icons"></span>
+        </a>
+        {# Avoid padding in the content, move details as child #}
+        <div class="ds-toggle__content" style="display: none">
+          <div class="ds-custom-type__crating--details ds-type--set-crating" data-type="crating-details"></div>
+        </div>
+      </div>
+  {% endif %}
+  <div 
+    id="{{ rootId }}"
+    class="ds-custom-type{{ cls }}" 
+    data-target="self" 
+    style="{{ options.mainStyle }}">
+    {% if options.header %}
+      <div class="ds-custom-type__header{% if options.detect %} ds-type--detect{% endif %}" data-target="#{{ rootId }} .ds-custom-type__preview">
+        <span class="ds-type--set" data-type="font">{{ options.font }}</span>
+      </div>
+    {% endif %} 
+    {% for item in collection %}
+      {% set label = item.label if item.label else 'Paragraph' %}
+      <div class="ds-custom-type__item{% if options.detect %} ds-type--detect{% endif %}" data-target=".ds-custom-type__preview">
+        <div class="ds-custom-type__meta">
+          {{ label }}
+          {% if item.varName %}
+            <div>{{ item.varName }}</div>
+          {% endif %}
+        </div>
+        {{ customTypePreview(item, options) }}
+        {% if options.details %}
+          {{ details(item, options) }}
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+  {% if options.rating %}
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% macro headingPreview(item, options) %}
   {% set cls = ' ' + item.cls if item.cls %}
   {% if item.truncate %}
@@ -202,6 +275,15 @@ Verba tu fingas et ea dicas, quae non sentias?
   <p{%if options.id%} id="{{ options.id }}"{%endif%} class="ds-paragraph__preview{{ cls }}" style="{{ item.previewStyle }}">
     {{ content }}
   </p>
+{% endmacro %}
+
+{% macro customTypePreview(item, options) %}
+  {% set cls = ' ' + item.cls if item.cls %}
+  {% set content = item.content %}
+  {% set tag = item.tag %}
+  <{{ tag }}{%if options.id%} id="{{ options.id }}"{%endif%} class="ds-custom-type__preview{{ cls }}" style="{{ item.previewStyle }}">
+    {{ content }}
+  </{{ tag }}>
 {% endmacro %}
 
 {% macro details(item, options) %}

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/types.njk
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/docs/99-tools/types.njk
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block preview %}
-  {% dssection 'Heading usage' %}
+  {% dssection 'Headings' %}
     {% dscodecell 6, 'njk' %}
       {% raw %}
         {# Usage #}
@@ -409,7 +409,7 @@
     {% enddscodecell %}
   {% enddssection %}
 
-  {% dssection 'Paragraph usage' %}
+  {% dssection 'Paragraphs' %}
     {% dscodecell 6, 'njk' %}
       {% raw %}
       {# Usage #}
@@ -677,7 +677,227 @@
     {% enddscodecell %}
   {% enddssection %}
 
-  {% dssection 'Types usage' %}
+
+  {% dssection 'Custom types' %}
+    {% dscodecell 6, 'njk' %}
+      {% raw %}
+      {# Usage #}
+      {% import "@corllete/apos-ds-page-type:components/story/type.html" as types %}
+
+      {# Render in grid cell #}
+      {{ types.custom(items, options) }}
+      {# No grid #}
+      {{ types.customTypes(items, options) }}
+      {% endraw %}
+    {% enddscodecell %}
+    {% dscell 4 %}
+      <div class="ds-typography--code">
+        General use of the custom types macro. When rendered with grid, 
+        <code>options.span</code> controls the cell span. 
+      </div>
+    {% enddscell %}
+  {% enddssection %}
+
+
+
+  {% dssection 'Custom types basic example' %}
+    {{ types.custom(['strong', 'em'], { span: 6, background: '#f8f8f8', label: 'Custom label from options' }) }}
+    {% dscell 4 %}
+      <div class="ds-typography--code">
+        Basic custom type (think of tag) render based on provided tag name and background color, span and label options. 
+        It renders <code>strong, em</code> applying only the provided options with no additional styling coming from the design system.
+        The rest is up to your global application styles. 
+      </div>
+    {% enddscell %}
+    {% dscodecell 12, 'njk', { toggle: false } %}
+      {% raw %}
+      {% import "@corllete/apos-ds-page-type:components/story/type.html" as types %}
+
+      {{ types.custom(['strong', 'em'], { span: 6, background: '#f8f8f8', label: 'Custom label from options' }) }}
+      {% endraw %}
+    {% enddscodecell %}
+  {% enddssection %}
+
+  {% dssection 'Custom type options and definition' %}
+    {{ types.custom([
+      {
+        tag: 'blockquote',
+        content: 'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci. Sed in libero ut nibh placerat accumsan. Donec orci lectus, aliquam ut, faucibus non, euismod id, nulla. Nulla facilisi. Nam at tortor in tellus interdum sagittis.',
+        label: 'Quotes'
+      },
+      {
+        tag: 'em',
+        content: 'An emphasis example'
+      }
+    ], { 
+      span: 4, 
+      color: '#ffffff',
+      metaColor: '#ffffff',
+      background: '#ff5555', 
+      label: 'Custom label from options',
+      weight: 400,
+      tracking: 'normal',
+      small: true,
+      details: true
+    }) }}
+    {% dscell 4 %}
+      <div class="ds-typography--code">
+        The definition is the same as paragraph with the exception of <code>content, tag</code>.
+        <code>xsmall | small | medium | large </code> options are not available as the predefined text is replaced by
+        <code>content</code> definition key.
+      </div>
+    {% enddscell %}
+    {% dscodecell 12, 'njk', { toggle: false } %}
+      {% raw %}
+      {% import "@corllete/apos-ds-page-type:components/story/type.html" as types %}
+
+      {{ types.custom([
+        {
+          tag: 'blockquote',
+          content: 'A blockquote example',
+          label: 'Quotes'
+        },
+        {
+          tag: 'em',
+          content: 'An emphasis example'
+        }
+      ], { 
+        span: 4, 
+        color: '#ffffff',
+        metaColor: '#ffffff',
+        background: '#ff5555', 
+        label: 'Custom label from options',
+        weight: 400,
+        tracking: 'normal',
+        small: true,
+        details: true
+      }) }}
+      {% endraw %}
+    {% enddscodecell %}
+  {% enddssection %}
+
+  {% dssection 'Custom type contrast rating' %}
+    {% dsrow %}
+      <div class="ds-typography--code">
+        Detect automatically the contrast rating according to WCAG 2.0 standards via option <code>rating: true</code>.
+        <code>detect: true</code> is not required in order this to work properly.
+        <p>This is also an example of providing the <code>content</code> definition key via options.
+      </div>
+    {% enddsrow %}
+    {{ types.custom(['em'], { 
+      span: 3, 
+      content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+      color: '#c0c0c0',
+      background: '#ffffff', 
+      metaColor: '#000',
+      rating: true,
+      small: true
+    }) }}
+    {{ types.custom(['strong'], { 
+      span: 3, 
+      content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+      color: '#ffffff',
+      background: '#ff5555', 
+      metaColor: '#ffffff',
+      rating: true,
+      small: true
+    }) }}
+    {{ types.custom(['code'], { 
+      span: 3, 
+      content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+      background: '#ffffff', 
+      rating: true,
+      small: true
+    }) }}
+    {{ types.custom(['blockquote'], { 
+      span: 3, 
+      content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+      background: 'rgba(255, 255, 255, 0.1)', 
+      rating: true,
+      small: true
+    }) }}
+    
+    {% dscodecell 12, 'njk', { toggle: false } %}
+      {% raw %}
+      {% import "@corllete/apos-ds-page-type:components/story/type.html" as types %}
+
+        {{ types.custom(['em'], { 
+          span: 3, 
+          content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+          color: '#c0c0c0',
+          background: '#ffffff', 
+          metaColor: '#000',
+          rating: true,
+          small: true
+        }) }}
+
+        {{ types.custom(['strong'], { 
+          span: 3, 
+          content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+          color: '#ffffff',
+          background: '#ff5555', 
+          metaColor: '#ffffff',
+          rating: true,
+          small: true
+        }) }}
+
+        {{ types.custom(['code'], { 
+          span: 3, 
+          content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+          background: '#ffffff', 
+          rating: true,
+          small: true
+        }) }}
+
+        {{ types.custom(['blockquote'], { 
+          span: 3, 
+          content: 'Aenean ut eros et nisl sagittis vestibulum. Etiam ultricies nisi vel augue.',
+          background: 'rgba(255, 255, 255, 0.1)', 
+          rating: true,
+          small: true
+        }) }}
+
+      {% endraw %}
+    {% enddscodecell %}
+  {% enddssection %}
+
+  {% dssection 'Custom types autodetect details' %}
+    {{ types.custom(['blockquote'], { 
+      span: 4, 
+      color: '#ffffff',
+      metaColor: '#ffffff',
+      background: '#ff5555', 
+      label: 'Custom label',
+      xsmall: true,
+      header: true,
+      details: true,
+      detect: true
+    }) }}
+    {% dscell 4 %}
+      <div class="ds-typography--code">
+        The <code>detect: true</code> options is auto-detecting all meta data from the computed dom style.
+      </div>
+    {% enddscell %}
+    {% dscodecell 12, 'njk', { toggle: false } %}
+      {% raw %}
+      {% import "@corllete/apos-ds-page-type:components/story/type.html" as types %}
+
+      {{ types.custom(['code', 'blockquote'], { 
+        span: 4, 
+        color: '#ffffff',
+        metaColor: '#ffffff',
+        background: '#ff5555', 
+        label: 'Custom label',
+        xsmall: true,
+        header: true,
+        details: true,
+        detect: true
+      }) }}
+      {% endraw %}
+    {% enddscodecell %}
+  {% enddssection %}
+
+  {% dssection 'Types Collection' %}
     {% dscodecell 6, 'njk' %}
       {% raw %}
       {# Usage #}
@@ -699,7 +919,17 @@
   {% dssection 'Types example' %}
     {{ types.cell({ 
       headings: [38, 28, 21], 
-      paragraphs: ['20/30', '15/22.5'] 
+      paragraphs: ['20/30', '15/22.5'],
+      custom: [
+        {
+          tag: 'blockquote',
+          content: 'Praesent ut ligula non mi varius sagittis. Curabitur blandit mollis lacus. Aenean tellus metus, bibendum sed, posuere ac, mattis non, nunc.'
+        },
+        {
+          tag: 'small',
+          content: 'Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Quisque libero metus, condimentum nec, tempor a, commodo mollis, magna. Integer tincidunt.'
+        }
+      ]
     }, { span: 6, background: '#f8f8f8' }) }}
     {% dscell 4 %}
       <div class="ds-typography--code">


### PR DESCRIPTION
Add custom type to render any provided tag and content (based on paragraph type). Improve fonts detection.

closes #3