### PR TITLE
feat(ds-page-type): add story helpers

### DIFF
--- a/packages/apos-ds/index.js
+++ b/packages/apos-ds/index.js
@@ -119,14 +119,31 @@ module.exports = {
       },
 
       // Apply all required story filters
-      async applyStoryFilters(req, stories) {
-        await self.addStoryUrls(req, stories);
+      async applyStoryFilters(req, config) {
+        await self.addStoryUrls(req, config);
       },
 
       // Set the request context for stories, used in pages module
       async setStoryContext(req) {
         req.data.config = JSON.parse(JSON.stringify(self.config));
         await self.applyStoryFilters(req, req.data.config);
+      },
+
+      getStory(id) {
+        const config = self.getStoryConfigFor(id);
+        if (!config) {
+          return;
+        }
+        return config.stories.find(s => s._id === id);
+      },
+
+      getStoryConfigFor(storyId) {
+        const index = self.storyIndex[storyId];
+        if (!index) {
+          return;
+        }
+
+        return self.config[index.config];
       },
 
       checkForWarnings() {

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/index.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/index.js
@@ -176,6 +176,14 @@ module.exports = {
         });
       },
 
+      getStory(id, config) {
+        const storyConfig = self.apos.ds.getStoryConfigFor(id);
+        if (!storyConfig || !config) {
+          return;
+        }
+        return (config[storyConfig._id] || [ { stories: [] } ]).stories.find(s => s._id === id);
+      },
+
       // the common context for all owned routes
       async setCommonContext(req) {
         await Promise.all([
@@ -204,9 +212,10 @@ module.exports = {
       },
 
       // this will go soon
-      async themePage(req) {
-        self.setTemplate(req, 'theme');
-      },
+      // this is gone
+      // async themePage(req) {
+      //   self.setTemplate(req, 'theme');
+      // },
 
       // module index - list all stories
       async indexPage(req) {

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/lib/helpers.js
@@ -1,5 +1,5 @@
 // nunjucks helpers
-module.exports = function (self, options) {
+module.exports = function (self) {
   if (!self.apos.ds.options.enabled) {
     return {};
   }
@@ -7,14 +7,47 @@ module.exports = function (self, options) {
   const { normalizeTypeHelper, normalizeTypeOptionsHelper } = require('./utils.js');
 
   return {
-    stylesheet: function (name, urlOnly = false) {
+    /**
+     * Id is the last portion of the URL of story preview
+     *
+     * Usage:
+     * `apos.dsp.story('atoms-buttons-fab', data.config)`
+     *
+     * @param {String} id
+     * @param {Object} config the entire story data
+     * @returns {Object} story
+     */
+    story(id, config) {
+      if (!config) {
+        return self.apos.ds.getStory(id);
+      }
+
+      return self.getStory(id, config);
+    },
+
+    /**
+     * Id is the last portion of the URL of story preview
+     *
+     * Usage:
+     * `apos.dsp.storyData('atoms-buttons-fab')`
+     *
+     * @param {String} id
+     * @returns {Object} story data
+     */
+    storyData(id) {
+      return (self.apos.ds.getStory(id) || {}).data;
+    },
+
+    stylesheet(name, urlOnly = false) {
       return self.stylesheetHelper(name, urlOnly);
     },
 
-    script: function (name, urlOnly = false) {
+    script(name, urlOnly = false) {
       return self.scriptHelper(name, urlOnly);
     },
 
+    // Internals, used in macros/fragments
+    // Use it at your own risk, they may change
     storyState(state, small) {
       const cls = small ? ' ds-state--small' : '';
       switch (state) {

--- a/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/categoryList.html
+++ b/packages/apos-ds/modules/@corllete/apos-ds-page-type/views/components/categoryList.html
@@ -29,13 +29,13 @@
  # @key {String:Boolean} list if it should render its stories in list
  # @enddef
  #
- # @todo parse-doc for Nunjucks
+ # FIXME break it down again to helper fragments now when fragments are working again
  #}
 {% fragment render(list, categories, configs, options) %}
 
   <div class="ds-category-list">
     {% set found = 0 %}
-    {% for id, category in list %}
+    {% asyncEach id, category in list %}
       {% if category.list and category.all.length > 0 %}
 
         {# Meta #}
@@ -54,7 +54,7 @@
         {% endif %}
 
         {# Stories #}
-          {% for configName in category.all %}
+          {% asyncEach configName in category.all %}
 
             {% set config = configs[configName] %}
             {% set scat = categories[config.categoryId] %}
@@ -67,7 +67,7 @@
             {% endif %}
 
               
-            {% for story in config.stories %}
+            {% asyncEach story in config.stories %}
               {% if story.list %}
                 {% set found = found + 1 %}
                 <div class="ds-category-list__story">
@@ -88,12 +88,12 @@
                   {% include tmpl %}
                 </div>
               {% endif %}
-            {% endfor %}
+            {% endeach %}
 
-          {% endfor %}
+          {% endeach %}
 
       {% endif %}
-    {% endfor %}
+    {% endeach %}
 
     {% if found == 0 %}
     {% dshint 'neutral' %}


### PR DESCRIPTION
Add apos.dsp.story() and apos.dsp.storyData() helpers to retrieve respectively a story or story data object. Revert back the asyncEach based on the latest apos async templating findings.

clsoes #30